### PR TITLE
add auto-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a list of links to all things awesome, related to Zed a
 - [Loungy](https://github.com/MatthiasGrandl/loungy): App launcher in the vein of Spotlight, Alfred, Raycast.
 - [Duane Bester - Rust Streams](https://www.youtube.com/watch?v=OHU-Y93eCs8&list=PLzIkykhdNahwxfVbxgZR69TQSsJc-6Rqq): Great deep dive into GPUI code.
 - [gpui-calculator](https://github.com/kriskw1999/gpui-calculator): Beautifully designed calculator with both keys and mouse interaction.
+- [auto-ui](https://github.com/auto-stack/auto-ui): Writing GPUI apps with the Auto scripting language.
 
 ## Misc
 


### PR DESCRIPTION
[auto-ui](https://github.com/auto-stack/auto-ui) is a UI framework based on GPUI and [GPUI-Component](https://github.com/longbridge/gpui-component).

auto-ui uses [auto-lang](https://github.com/auto-stack/auto-lang), a scripting language written in Rust,
to describe the UI layout, similar to `rsx!` macros in [Dioxus](https://github.com/DioxusLabs/dioxus).

Here is a simple Counter example written in auto-ui:

```rust
widget counter {
    model {
        var count = 0
    }
    view {
        button("+") {
            onclick: || count = count + 1
        }
        text(f"Count: $count")
        button("-") {
            onclick: || count = count - 1
        }
        button("reset") {
            onclick: || count = 0
        }
    }
}
```

and the UI it generates:

![auto-ui counter example](https://foruda.gitee.com/images/1730021021429704035/4625e3ce_142056.png)

