### PR TITLE
docs: add gpui-nav to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [gpui-router](https://github.com/justjavac/gpui-router): A router for GPUI App.
 - [adabraka-ui](https://github.com/Augani/adabraka-ui): UI components for building beautiful desktop applications
 - [gpui-video-player](https://github.com/cijiugechu/gpui-video-player): Video player for gpui.
+- [gpui-nav](https://github.com/benodiwal/gpui-nav): Easy navigation library for GPUI applications.
 
 ## Tooling
 


### PR DESCRIPTION
## Add gpui-nav - Navigation primitives for GPUI

### What's this?
A simple navigation library for GPUI apps. Handles screen transitions with a clean stack-based approach.

### The Problem
I found myself rewriting navigation logic across different GPUI projects, so I extracted it into a reusable library.

### The Solution
`gpui-nav` provides basic navigation operations that integrate naturally with GPUI's patterns.
```rust
// Push and pop screens
app.navigator.push(new_screen, cx);
app.navigator.pop(cx);
```

### Example
Check the [basic_navigation example](examples/basic_navigation/) to see it in action - a simple app with login, profiles, and settings screens.

### Links
- 📦 [Crate](https://crates.io/crates/gpui-nav)
- 📖 [Docs](https://docs.rs/gpui-nav)
- 💻 [GitHub](https://github.com/benodiwal/gpui-nav)

---

Happy to hear feedback or suggestions!