### PR TITLE
Add Baudrun to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A hybrid immediate and retained mode, GPU accelerated, UI framework for Rust, de
 
 - [zed](https://github.com/zed-industries/zed): A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
 - [Arbor](https://github.com/penso/arbor): Run agentic coding workflows in a fully native desktop app for Git worktrees, terminals, and diffs.
+- [Baudrun](https://github.com/packetThrower/Baudrun): A cross-platform serial terminal for network engineers, with saved profiles, multi-window, auto-reconnect, and XMODEM/YMODEM file transfer.
 - [DBFlux](https://github.com/0xErwin1/dbflux): A keyboard-first, multi-engine database client for SQLite, PostgreSQL, MySQL, MongoDB, Redis, and DynamoDB with integrated MCP governance for AI agents.
 - [Fulgur](https://github.com/fulgur-app/Fulgur): A lightning-fast, multiplatform, fully themed text & code editor with secured file sync between devices.
 - [GitComet](https://github.com/Auto-Explore/GitComet): GitComet is fastest open source user interface for GIT workflows.


### PR DESCRIPTION
## Summary

- Adds Baudrun to the Developer Tools section.
- Baudrun is a cross-platform (macOS / Windows / Linux) serial terminal aimed at network engineers — console sessions for switches, routers, firewalls, and other RS-232-attached gear.
- Built on gpui + gpui-component + alacritty_terminal, single-crate Rust.
- Features: saved profiles per device, auto-reconnect across cable pulls, XMODEM / XMODEM-CRC / XMODEM-1K / YMODEM file transfer, vendor-aware syntax highlighting (Cisco IOS, Junos, Aruba AOS-CX, Arista EOS, MikroTik RouterOS), 16 app skins, 15 terminal themes.

## Repo

https://github.com/packetThrower/Baudrun