### PR TITLE
Add Futureboard Studio to Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A hybrid immediate and retained mode, GPU accelerated, UI framework for Rust, de
 - [Monocurl](https://github.com/monocurl/monocurl/): An environment for programmatically animating images, videos, and slideshows in the Monocurl language.
 - [sukusho](https://github.com/ssut/sukusho): A powerful screenshot manager for Windows.
 - [vleer](https://github.com/vleerapp/vleer): Music, but without the subscription. Built on top of the OpenMusic API for a new streaming standard.
+- [Futureboard Studio](https://github.com/futureboard/Futureboard): An open-source digital audio workstation with Native GPUI, React WebUI, Rust DSP, and native plugin hosting.
 
 ### System Utilities
 


### PR DESCRIPTION
# Summary

- Adds Futureboard Studio to the Media section.
- Futureboard Studio is an open-source, cross-platform DAW and creative audio platform currently being developed with a Rust native GPUI interface.
- The project is migrating from its WebUI/Electron prototype toward a native Studio edition while keeping Web and Electron variants in the ecosystem.
- Current development focuses on the native timeline, waveform rendering, mixer UI, project workflow, plugin-hosting foundations, and direct Rust audio engine integration.al themes.

## Repo

https://github.com/futureboard/Futureboard