### PR TITLE
Add declarative-gpui to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A hybrid immediate and retained mode, GPU accelerated, UI framework for Rust, de
 ## Libraries
 
 - [adabraka-ui](https://github.com/Augani/adabraka-ui): UI components for building beautiful desktop applications.
+- [declarative-gpui](https://github.com/DevPlus31/declarative-gpui): A declarative ui! macro with Tailwind-style tokens, real Rust control flow, and zero runtime overhead.
 - [ferrum-flow](https://github.com/tu6ge/ferrum-flow): A high-performance, extensible node-based editor framework.
 - [gpui-component](https://github.com/longbridge/gpui-component): UI components for building fantastic desktop applications using gpui.
 - [gpui-d3rs](https://github.com/pierreaubert/sotf/tree/master/gpui-d3rs): a low level plotting library 100% in rust with the familiar [d3js](https://d3js.org/) components.


### PR DESCRIPTION
Adds [declarative-gpui](https://github.com/DevPlus31/declarative-gpui) to the Libraries section (alphabetical order).

A declarative `ui!` proc-macro for building GPUI element trees: Tailwind-style tokens (`px_8`, `bg_1c1a17`, `rounded_lg`), real Rust control flow (`if`/`for`/`match`) inside the tree, and zero runtime overhead — every token compiles directly to GPUI builder calls, with colors precomputed to `Hsla` at compile time. Style-token coverage is verified against GPUI's `Styled` API, and an integration crate compiles the full DSL surface against a pinned zed rev in CI.

- crates.io: https://crates.io/crates/declarative-gpui
- The repo includes a side-by-side showcase example (same UI hand-written vs macro, pixel-identical, 72% less code).