### PR TITLE
Improve guise description

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -491,7 +491,7 @@
       "name": "guise",
       "category": "Libraries",
       "url": "https://github.com/wess/guise",
-      "description": "A nice set of components for gpui."
+      "description": "A Mantine-inspired component library with theming, sizing tokens, and a large set of ready-made components."
     },
     {
       "name": "plotters-gpui",


### PR DESCRIPTION
Updates the description for the existing guise entry in projects.json to say what the library actually is (Mantine-inspired, theming, sizing tokens, component breadth). Description-only change: category, url, and alphabetical position are untouched, and the JSON stays schema-valid.
