### PR TITLE
Update Futureboard Studio image

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -280,7 +280,7 @@
       "category": "Apps",
       "subcategory": "Media",
       "url": "https://github.com/futureboard/Futureboard",
-      "image": "https://raw.githubusercontent.com/futureboard/Futureboard/main/packages/assets/banner.png",
+      "image": "https://raw.githubusercontent.com/futureboard/futureboard/main/packages/shared/app/icons/app.png",
       "description": "An open-source digital audio workstation with Native GPUI, React WebUI, Rust DSP, and native plugin hosting."
     },
     {


### PR DESCRIPTION
## Summary

- replace the Futureboard Studio banner with its repository-hosted app icon

## Validation

- `uv run check-jsonschema --schemafile projects.schema.json projects.json`
- `uv run scripts/sort_projects.py --check`
- `uv run scripts/generate_readme.py`