### PR TITLE
Add OpenMango

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -126,6 +126,14 @@
       "description": "A GPU-accelerated, cross-platform desktop client for PostgreSQL, MySQL, SQLite, SQL Server, Oracle, ClickHouse, DuckDB, Redis, MongoDB, SSH, SFTP, serial, terminals, and AI in one place."
     },
     {
+      "name": "OpenMango",
+      "category": "Apps",
+      "subcategory": "Developer Tools",
+      "url": "https://github.com/ggagosh/openmango",
+      "image": "https://raw.githubusercontent.com/ggagosh/openmango/main/assets/logo/openmango.iconset/icon_256x256.png",
+      "description": "A native, GPU-accelerated MongoDB workbench for macOS, built with Rust and GPUI."
+    },
+    {
       "name": "pgui",
       "category": "Apps",
       "subcategory": "Developer Tools",


### PR DESCRIPTION
## Summary

Adds [OpenMango](https://github.com/ggagosh/openmango) to Apps → Developer Tools. OpenMango is a native, GPU-accelerated MongoDB workbench for macOS, built with Rust and GPUI.

## Checklist

- [x] I edited `projects.json`, not the generated `README.md`.
- [x] I validated and sorted the project data.

```sh
uv run check-jsonschema --schemafile projects.schema.json projects.json
uv run scripts/sort_projects.py --check
```