### PR TITLE
Add Waku

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -190,6 +190,13 @@
       "description": "A GPU-rendered, daemon-backed terminal in pure Rust — a persistent daemon holds the PTYs so sessions survive quitting the app (no tmux needed), with an enhanced prompt, tabs, splits, a command palette, and native builds for macOS, Windows, and Linux."
     },
     {
+      "name": "Waku",
+      "category": "Apps",
+      "subcategory": "Developer Tools",
+      "url": "https://github.com/egoist/waku",
+      "description": "A fast, native desktop app for working with local coding agents."
+    },
+    {
       "name": "zed",
       "category": "Apps",
       "subcategory": "Developer Tools",


### PR DESCRIPTION
## Summary

- add Waku under Apps / Developer Tools
- use the canonical GitHub URL and the project description

## Validation

- `uv run check-jsonschema --schemafile projects.schema.json projects.json`
- `uv run scripts/sort_projects.py --check`
- `uv run scripts/generate_readme.py` (generated Waku entry reviewed; README restored as required)