### PR TITLE
Add Zeron

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -205,6 +205,14 @@
       "description": "A blazing-fast, native Redis GUI built with Rust and GPUI."
     },
     {
+      "name": "Zeron",
+      "category": "Apps",
+      "subcategory": "Developer Tools",
+      "url": "https://github.com/zeronsh/comet",
+      "image": "https://raw.githubusercontent.com/zeronsh/comet/main/dist/macos/icon-1024.png",
+      "description": "A native app that controls coding agents, for example Claude Code, Codex, and Cursor. It keeps all sessions on your device. If you connect more devices, you can start an agent on one device and control it from a different device."
+    },
+    {
       "name": "zlyph",
       "category": "Apps",
       "subcategory": "Developer Tools",


### PR DESCRIPTION
This PR adds [Zeron](https://github.com/zeronsh/comet) to Apps → Developer Tools.

Zeron is a native app, built with GPUI, that controls coding agents (Claude Code, Codex, Cursor, Grok, Hermes, Pi). It keeps all sessions on your device by default. If you connect more devices, you can start an agent on one device and control it from a different device.

Only `projects.json` is changed; `scripts/sort_projects.py --check` and the schema validation pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)