### PR TITLE
Add OxiMux

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -149,6 +149,14 @@
       "description": "A native, GPU-accelerated MongoDB workbench for macOS, built with Rust and GPUI."
     },
     {
+      "name": "OxiMux",
+      "category": "Apps",
+      "subcategory": "Developer Tools",
+      "url": "https://github.com/nhtera/OxiMux",
+      "image": "https://raw.githubusercontent.com/nhtera/OxiMux/main/apps/landing/public/apple-touch-icon.png",
+      "description": "A multi-agent development cockpit for macOS. Open a repo, spawn isolated Git worktrees, run CLI coding agents such as Claude Code, Codex, and Aider side by side, and review every change through a built-in Git UI."
+    },
+    {
       "name": "pgui",
       "category": "Apps",
       "subcategory": "Developer Tools",


### PR DESCRIPTION
This PR adds [OxiMux](https://github.com/nhtera/OxiMux) to Apps → Developer Tools.

OxiMux is a Rust-native, multi-agent development cockpit for macOS, built with GPUI. Open a repo, spawn isolated Git worktrees, run CLI coding agents (Claude Code, Codex, Aider, and others) side by side, and review every change through a built-in Git UI with diffs and a commit graph.

Only `projects.json` is changed; `check-jsonschema` and `scripts/sort_projects.py --check` pass locally.

## Checklist

- [x] I edited `projects.json`, not the generated `README.md`.
- [x] I validated and sorted the project data.