### PR TITLE
Use the DBFlux app icon rather than a screenshot

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -44,7 +44,7 @@
       "category": "Apps",
       "subcategory": "Developer Tools",
       "url": "https://github.com/0xErwin1/dbflux",
-      "image": "https://raw.githubusercontent.com/0xErwin1/dbflux/main/resources/dbflux.png",
+      "image": "https://raw.githubusercontent.com/0xErwin1/dbflux/main/resources/icon.png",
       "description": "A keyboard-first, multi-engine database client for SQLite, PostgreSQL, MySQL, MongoDB, Redis, and DynamoDB with integrated MCP governance for AI agents."
     },
     {


### PR DESCRIPTION
The DBFlux entry points at `resources/dbflux.png`, which is a 1908x1036 screenshot of the app. At `height="64"` it renders as a 118x64 strip of unreadable UI, while every neighbouring entry links its square app icon.

Swapped it for `resources/icon.png`, the app icon itself at 1024x1024.

## Checklist

- [x] I edited `projects.json`, not the generated `README.md`.
- [x] I validated and sorted the project data.

```sh
uv run check-jsonschema --schemafile projects.schema.json projects.json
# ok -- validation done
uv run scripts/sort_projects.py --check
# projects.json is sorted.
```