### PR TITLE
Add Steward to Productivity apps

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -350,6 +350,14 @@
       "description": "A keyboard-first, multi-document scratchpad for Rust code and text blocks on macOS, built with GPUI, GPUI Component, and SQLite."
     },
     {
+      "name": "Steward",
+      "category": "Apps",
+      "subcategory": "Productivity",
+      "url": "https://github.com/iFence/steward",
+      "image": "https://raw.githubusercontent.com/iFence/steward/master/assets/steward.png",
+      "description": "A small, polished launcher and plugin platform for Windows, built with Rust, GPUI, and gpui-component."
+    },
+    {
       "name": "Vellum",
       "category": "Apps",
       "subcategory": "Productivity",


### PR DESCRIPTION
## Checklist

- [x] I edited `projects.json`, not the generated `README.md`.
- [x] I validated and sorted the project data.

```sh
uv run check-jsonschema --schemafile projects.schema.json projects.json
uv run scripts/sort_projects.py --check
```

## Description

Adds [Steward](https://github.com/iFence/steward), a small, polished launcher and plugin platform for Windows built with Rust, GPUI, and `gpui-component`, to the Productivity apps section.
