### PR TITLE
Add TokenMonitor to Developer Tools apps

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -207,6 +207,14 @@
       "description": "A Lightweight & GPU-rendered terminal emulator, written in Rust."
     },
     {
+      "name": "TokenMonitor",
+      "category": "Apps",
+      "subcategory": "Developer Tools",
+      "url": "https://github.com/iFence/TokenMonitor",
+      "image": "https://raw.githubusercontent.com/iFence/TokenMonitor/main/resources/tokenmonitor.png",
+      "description": "A native Windows desktop app for tracking token usage across AI coding tools (Claude Code, Codex, and more), built with Rust and GPUI."
+    },
+    {
       "name": "tty7",
       "category": "Apps",
       "subcategory": "Developer Tools",


### PR DESCRIPTION
## Checklist

- [x] I edited `projects.json`, not the generated `README.md`.
- [x] I validated and sorted the project data.

```sh
uv run check-jsonschema --schemafile projects.schema.json projects.json
uv run scripts/sort_projects.py --check
```

## Description

Adds [TokenMonitor](https://github.com/iFence/TokenMonitor), a native Windows desktop app for tracking token usage across AI coding tools (Claude Code, Codex, and more) built with Rust and GPUI, to the Developer Tools apps section.
