### PR TITLE
Add CLV3000-Plus disk cleaner to projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -493,6 +493,14 @@
       "description": "Per-program network usage monitor for Linux."
     },
     {
+      "name": "CLV3000-Plus",
+      "category": "Apps",
+      "subcategory": "System Utilities",
+      "url": "https://github.com/sopaco/CLV3000-Plus",
+      "image": "https://raw.githubusercontent.com/sopaco/CLV3000-Plus/main/assets/icons/icon_app.png",
+      "description": "The only disk cleaner that understands agent works. Blazing-fast, safe by GPUI."
+    },
+    {
       "name": "clp",
       "category": "Apps",
       "subcategory": "System Utilities",


### PR DESCRIPTION
This PR adds [CLV3000 Plus](https://github.com/sopaco/CLV3000-Plus) to Apps.

The only disk cleaner that understands agent works. Blazing-fast, safe by GPUI

schema validation and scripts/sort_projects.py --check pass locally.