### PR TITLE
Add GPUI Kit Canvas

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -768,6 +768,12 @@
       "description": "One UI codebase for desktop, web, mobile, terminal, browser extensions, and embedded devices. Write React JSX or our lightweight DSL, get GPUI, Ratatui, SwiftUI, LVGL, and more. Batteries included. [Official site](https://crepuscularity.tsc.hk)."
     },
     {
+      "name": "GPUI Kit Canvas",
+      "category": "Tooling",
+      "url": "https://github.com/JetSquirrel/gpui-kit-canvas",
+      "description": "A browser-based visual canvas for designing gpui-kit desktop windows and generating implementation prompts."
+    },
+    {
       "name": "Pulsar-Native",
       "category": "Tooling",
       "url": "https://github.com/Far-Beyond-Pulsar/Pulsar-Native",

--- a/projects.json
+++ b/projects.json
@@ -771,6 +771,7 @@
       "name": "GPUI Kit Canvas",
       "category": "Tooling",
       "url": "https://github.com/JetSquirrel/gpui-kit-canvas",
+      "image": "https://raw.githubusercontent.com/JetSquirrel/gpui-kit-canvas/main/app/icon.svg",
       "description": "A browser-based visual canvas for designing gpui-kit desktop windows and generating implementation prompts."
     },
     {


### PR DESCRIPTION
## Summary

- add GPUI Kit Canvas to the Tooling section
- describe its visual gpui-kit window design and prompt-generation workflow

## Validation

- `uv run check-jsonschema --schemafile projects.schema.json projects.json`
- `uv run scripts/sort_projects.py --check`
- generated and reviewed `README.md`, then restored it as required